### PR TITLE
Added findRoute() method to Router class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea/

--- a/exception/MethodNotAllowedException.php
+++ b/exception/MethodNotAllowedException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace thecodeholic\phpmvc\exception;
+
+
+/**
+ * Class MethodNotAllowedException
+ *
+ * @package thecodeholic\phpmvc\exception
+ * @author Ar Rakin <rakinar2@gmail.com>
+ */
+class MethodNotAllowedException extends \Exception
+{
+    protected $message = 'The request method is not allowed for this URL';
+    protected $code = 405;
+}


### PR DESCRIPTION
Think that our `public/index.php` file looks like this:

```php
<?php
//...

$app->router->get('/test', [SiteController::class, 'test']);

//...
```

And now if we try to access route `/test` with method `POST`, then it will return `404 Not Found`, which is not very good status for this case. The router should return `405 Method Not Allowed` instead.

In this commit, I've added a method `findRoute()` which finds a route, and returns the route action, method and the URI.

@thecodeholic 