### PR TITLE
sql statement error fixed

### DIFF
--- a/db/DbModel.php
+++ b/db/DbModel.php
@@ -48,7 +48,7 @@ abstract class DbModel extends Model
     {
         $tableName = static::tableName();
         $attributes = array_keys($where);
-        $sql = implode("AND", array_map(fn($attr) => "$attr = :$attr", $attributes));
+        $sql = implode(" AND ", array_map(fn($attr) => "$attr = :$attr", $attributes));
         $statement = self::prepare("SELECT * FROM $tableName WHERE $sql");
         foreach ($where as $key => $item) {
             $statement->bindValue(":$key", $item);


### PR DESCRIPTION
**Error explanation:**

The line ` implode("AND", array_map(fn($attr) => "$attr = :$attr", $attributes));`
 will produce an error **"Invalid parameter number: parameter was not defined"**
because if the item in the array `$attributes`  is greater than 1 then it will separate them by AND but there is **no gap** between them.

eg: **attr1 = :attr1ANDattr2 = :attr2**

so it will produce an error.


**Fix:** 

By adding a single space character before and after the separator **AND**
` implode(" AND ", array_map(fn($attr) => "$attr = :$attr", $attributes));` 
will produce:

**attr1 = :attr1 AND attr2 = :attr2**

this is the right syntax... 😊


