### PR TITLE
get query string as an object through Request class

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * User: TheCodeholic
  * Date: 7/7/2020
@@ -76,5 +77,16 @@ class Request
     public function getRouteParam($param, $default = null)
     {
         return $this->routeParams[$param] ?? $default;
+    }
+    /**
+     * @return object
+     */
+    public function getQueryString()
+    {
+        // get the full url with query string
+        $url  = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+        $parts = parse_url($url);
+        parse_str($parts['query'], $query);
+        return json_decode(json_encode($query), FALSE); // return query string as object
     }
 }


### PR DESCRIPTION
>Using **$request->getQueryString()** method to easily gets a query string as an object. For Example  

```PHP
  public function profileByName(Request $request)
    {
        echo '<pre>';
        // http://127.0.0.1:8080/profile/marufsharia?id=123&categoryId=102&type=small
        var_dump($request->getQueryString()->catagoryId); // output : 102
        echo '</pre>';
    }
```